### PR TITLE
Allow support for explicit lwjgl versions

### DIFF
--- a/src/main/kotlin/link/infra/packwiz/installer/LauncherUtils.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/LauncherUtils.kt
@@ -47,6 +47,8 @@ class LauncherUtils internal constructor(private val opts: UpdateManager.Options
 		var manifestModified = false
 		val modLoaders = hashMapOf(
 			"net.minecraft" to "minecraft",
+			"org.lwjgl" to "lwjgl",
+			"org.lwjgl3" to "lwjgl3",
 			"net.minecraftforge" to "forge",
 			"net.neoforged" to "neoforge",
 			"net.fabricmc.fabric-loader" to "fabric",


### PR DESCRIPTION
This allows for an explicitly defined version of LWJGL in the [versions] section of pack.toml. My reasoning for this is I distributed my modpack through multimc and shipped it with LWJGL version 3.3.3, in later updates of Sodium, this crashes.


low key this took me 6 hours to add two lines because i had to find the cmd line option to disable packwiz updating to test my local build but this works