### PR TITLE
Re-enables the use of relative URLs for mod download URLs

### DIFF
--- a/src/main/kotlin/link/infra/packwiz/installer/Main.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/Main.kt
@@ -5,6 +5,7 @@ package link.infra.packwiz.installer
 import link.infra.packwiz.installer.target.Side
 import link.infra.packwiz.installer.target.path.HttpUrlPath
 import link.infra.packwiz.installer.target.path.PackwizFilePath
+import link.infra.packwiz.installer.target.path.PackwizPath
 import link.infra.packwiz.installer.ui.cli.CLIHandler
 import link.infra.packwiz.installer.ui.gui.GUIHandler
 import link.infra.packwiz.installer.ui.wrap
@@ -74,7 +75,7 @@ class Main(args: Array<String>) {
 
 		val packFileRaw = unparsedArgs[0]
 
-		val packFile = when {
+		packFile = when {
 			// HTTP(s) URLs
 			Regex("^https?://", RegexOption.IGNORE_CASE).containsMatchIn(packFileRaw) -> ui.wrap("Invalid HTTP/HTTPS URL for pack file: $packFileRaw") {
 				HttpUrlPath(packFileRaw.toHttpUrl().resolve(".")!!, packFileRaw.toHttpUrl().pathSegments.last())
@@ -118,6 +119,8 @@ class Main(args: Array<String>) {
 	}
 
 	companion object {
+		lateinit var packFile: PackwizPath<*>
+
 		// Called by packwiz-installer-bootstrap to set up the help command
 		@JvmStatic
 		fun addNonBootstrapOptions(options: Options) {

--- a/src/main/kotlin/link/infra/packwiz/installer/metadata/ModFile.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/metadata/ModFile.kt
@@ -3,6 +3,7 @@ package link.infra.packwiz.installer.metadata
 import cc.ekblad.toml.delegate
 import cc.ekblad.toml.model.TomlValue
 import cc.ekblad.toml.tomlMapper
+import link.infra.packwiz.installer.Main
 import link.infra.packwiz.installer.metadata.curseforge.UpdateData
 import link.infra.packwiz.installer.metadata.hash.Hash
 import link.infra.packwiz.installer.metadata.hash.HashFormat
@@ -31,7 +32,15 @@ data class ModFile(
 	) {
 		companion object {
 			fun mapper() = tomlMapper {
-				decoder<TomlValue.String, PackwizPath<*>> { it -> HttpUrlPath(it.value.toHttpUrl()) }
+				decoder<TomlValue.String, PackwizPath<*>> { it ->
+					var path = it.value
+
+					if (!path.startsWith("http")) {
+						path = Main.packFile.resolve(path).toString()
+					}
+
+					HttpUrlPath(path.toHttpUrl())
+				}
 				mapping<Download>("hash-format" to "hashFormat")
 
 				delegateTransitive<HashFormat<*>>(HashFormat.mapper())


### PR DESCRIPTION
As mentioned in the commit, this should resolve #40 and https://github.com/packwiz/packwiz/issues/318, if you wish to test this, you can compile the jar via `./gradlew build` and then use this command `java -jar packwiz-installer-bootstrap.jar --bootstrap-no-update https://jordanplayz158.xyz/JordanPlayz158/packwiz-relative-url-example/-/raw/main/pack.toml`

Any recommendations on how I could do this better, let me know!